### PR TITLE
fix(dw-select-base-dialog): fix auto close issue in non mobile mode.

### DIFF
--- a/dw-select-base-dialog.js
+++ b/dw-select-base-dialog.js
@@ -187,8 +187,11 @@ export class DwSelectBaseDialog extends LitElement {
     document.removeEventListener('DOMMouseScroll', this._boundScrollHandler, options);
   }
 
-  _onCaptureClick(e) {
-    this.close();
+  /**
+   * When mobile mode, closes dialog on outside click.
+   */
+  _onCaptureClick() {
+    this.mobileMode && this.close();
   }
 
   _onDialogClick(e) {

--- a/dw-select-base-dialog.js
+++ b/dw-select-base-dialog.js
@@ -154,7 +154,7 @@ export class DwSelectBaseDialog extends LitElement {
   }
 
   _addDialogKeyEventListeners() {
-    this.addEventListener('click', this._onDialogClick);
+    this.addEventListener('mousedown', this._onDialogClick);
 
     let options = {
       capture: true,
@@ -170,7 +170,7 @@ export class DwSelectBaseDialog extends LitElement {
 
     setTimeout(() => {
       if(this.opened) {
-        document.addEventListener('click', this._onCaptureClick);
+        document.addEventListener('mousedown', this._onCaptureClick);
       }
     });
   }
@@ -180,8 +180,8 @@ export class DwSelectBaseDialog extends LitElement {
       capture: true,
       passive: false
     };
-    this.removeEventListener('click', this._onDialogClick);
-    document.removeEventListener('click', this._onCaptureClick);
+    this.removeEventListener('mousedown', this._onDialogClick);
+    document.removeEventListener('mousedown', this._onCaptureClick);
     document.removeEventListener('wheel', this._boundScrollHandler, options);
     document.removeEventListener('mousewheel', this._boundScrollHandler, options);
     document.removeEventListener('DOMMouseScroll', this._boundScrollHandler, options);

--- a/dw-select.js
+++ b/dw-select.js
@@ -634,7 +634,7 @@ export class DwSelect extends DwFormElement(LitElement) {
   
   _renderTriggerElement() {
     return html `
-      <div class="main-container" @click="${this._onClick}">
+      <div class="main-container" @mousedown="${this._onClick}">
         <div id="dropdownContainer">
           ${this._getTriggerElement()}
         </div>


### PR DESCRIPTION
Cause/Fix: Dialog should be closed on outside click in mobile mode but when it is popover, tippy js provide that feature so no need to implement our custom logic.