### PR TITLE
fix(dw-select): safari position issue.

### DIFF
--- a/dw-select-css.js
+++ b/dw-select-css.js
@@ -82,17 +82,8 @@ export const dwSelectStyle = css`
 
   .main-container #dropdownContainer .dropdown-input {
     display: flex;
-    display: -ms-flexbox;
-    display: -webkit-flex;
-    flex-direction: row;
-    -ms-flex-direction: row;
-    -webkit-flex-direction: row;
     align-items: center;
-    -ms-flex-align: center;
-    -webkit-align-items: center;
     justify-content: space-between;
-    -ms-flex-pack: space-between;
-    -webkit-justify-content: space-between;
     border-bottom: 1px solid var(--dw-select-border-color);
   }
 

--- a/dw-select-css.js
+++ b/dw-select-css.js
@@ -2,7 +2,7 @@ import { css } from "lit-element";
 
 export const dwSelectStyle = css`
   :host {
-    display: inline-block;
+    display: flex;
     box-sizing: border-box;
     width: var(--dw-select-width, 250px);
     --dw-select-error-color: var(--error-color);
@@ -18,21 +18,20 @@ export const dwSelectStyle = css`
   :host([trigger-icon]),
   :host([trigger-label]),
   :host([custom-trigger]) {
-    width: var(--dw-select-width, 100%);
+    width: var(--dw-select-width, auto);
   }
 
   .main-container {
-    display: inline-block;
-    width: 100%;
+    flex: 1;
   }
 
   :host([trigger-icon]) .main-container #dropdownContainer,
   :host([trigger-label]) .main-container #dropdownContainer,
   .main-container #dropdownContainer .trigger-icon,
   .main-container #dropdownContainer .trigger-label {
-    display: inline-block;
+    display: flex;
+    align-items: center;
     box-sizing: border-box;
-    width: 100%;
   }
 
   .main-container #dropdownContainer .trigger-icon,
@@ -153,6 +152,10 @@ export const dwSelectStyle = css`
 
   #select-dialog {
     border-radius: 4px;
+  }
+
+  [data-tippy-root] {
+    position: absolute;
   }
 `;
 


### PR DESCRIPTION
Cause: In Safari, when dialog opened, position:absolute set on tippy dialog but somehow  browser does not apply it.
Fix: Set position:absolute to the tippy dialog before it renders.