### PR TITLE
feat: `renderItem` refactor

### DIFF
--- a/demo/dw-select-extension-demo.js
+++ b/demo/dw-select-extension-demo.js
@@ -1,7 +1,9 @@
-import { LitElement, html, css } from "@dreamworld/pwa-helpers/lit.js";
+import "@dreamworld/dw-list-item";
+import { html } from "@dreamworld/pwa-helpers/lit.js";
+import isEqual from "lodash-es/isEqual.js";
 import { DwSelect } from "../dw-select";
 
-import { country_list, country_list_with_code, list, groupList, groups, accounts } from "./utils";
+import { country_list_with_code } from "./utils";
 
 export class DwSelectExtensionDemo extends DwSelect {
   constructor() {
@@ -11,6 +13,31 @@ export class DwSelectExtensionDemo extends DwSelect {
     this.label = "Extenstion Select";
     this.layout = "small";
     this.searchable = true;
+    this.renderItem = (item, selected, activated, query) =>
+      this._renderProductListItem(item, selected, activated, query);
+  }
+
+  _renderProductListItem(item, selected, activated, query) {
+    return html`
+      <dw-list-item
+        .title1=${item.value.name}
+        title2="${item.value?.code || ""}"
+        twoLine
+        ?selected=${selected}
+        .trailingIcon=${"done"}
+        .leadingIconFont=${"OUTLINED"}
+        ?hasTrailingIcon=${selected}
+        .highlight=${query}
+        ?activated=${activated}
+        @click=${(e) => this._onClick(item.value)}
+      ></dw-list-item>
+    `;
+  }
+
+  _onClick(value) {
+    this.value = value;
+    this._opened = false;
+    this.dispatchEvent(new CustomEvent("selection-done", { detail: value }));
   }
 
   get _footerTemplate() {

--- a/demo/select-demo.js
+++ b/demo/select-demo.js
@@ -134,7 +134,7 @@ class SelectDemo extends LitElement {
         @selected=${this._onSelect}
       ></dw-select>
 
-      <!-- <dw-select-extension-demo></dw-select-extension-demo> -->
+      <dw-select-extension-demo @selection-done=${this._onSelect}></dw-select-extension-demo>
 
       <!-- <dw-select-trigger label="Trigger" updatedHighlight></dw-select-trigger> -->
 

--- a/dw-select-base-dialog.js
+++ b/dw-select-base-dialog.js
@@ -551,20 +551,25 @@ export class DwSelectBaseDialog extends DwCompositeDialog {
     return html`
       <lit-virtualizer
         .items=${this._items}
-        .renderItem=${(item, index) =>
-          this.renderItem ? this.renderItem(item, index) : this._defaultTemplate(item, index)}
+        .renderItem=${(item, index) => {
+          const isSelected = this._isItemSelected(item.value);
+          const isActivated = this._isItemActivated(index);
+          return this.renderItem
+            ? this.renderItem(item, isSelected, isActivated, this._query)
+            : this._defaultTemplate(item, isSelected, isActivated, this._query);
+        }}
       ></lit-virtualizer>
     `;
   }
 
-  _defaultTemplate(item, index) {
+  _defaultTemplate(item, selected, activated, query) {
     if (item.type === "ITEM") {
       return html`<dw-list-item
         title1=${this._getItemValue(item.value)}
         .highlight=${this._query}
         @click=${() => this._onItemClick(item)}
-        ?activated=${index === this._activatedIndex}
-        ?selected=${this._isItemSelected(item.value)}
+        ?activated=${activated}
+        ?selected=${selected}
         .leadingIcon=${this._getLeadingIcon(item.value)}
         ?hasLeadingIcon=${this._hasLeadingIcon()}
         .trailingIcon=${this.selectedTrailingIcon}
@@ -577,8 +582,7 @@ export class DwSelectBaseDialog extends DwCompositeDialog {
       return html`<dw-select-group-item
         .name="${item.value.name}"
         .label="${this._getGroupValue(item.value)}"
-        .index="${index}"
-        ?activated=${index === this._activatedIndex}
+        ?activated=${activated}
         ?collapsible=${item.value.collapsible}
         ?collapsed=${item.value.collapsed}
         @click=${(e) => this._onGroupClick(e, item.value)}
@@ -608,7 +612,7 @@ export class DwSelectBaseDialog extends DwCompositeDialog {
   /**
    *
    * @param {Object} item Selected item, one of the `items`
-   * @returns whether item is selected or not.
+   * @returns {Boolean} whether item is selected or not.
    */
   _isItemSelected(item) {
     if (this.value && this.valueExpression) {
@@ -620,6 +624,15 @@ export class DwSelectBaseDialog extends DwCompositeDialog {
     }
 
     return false;
+  }
+
+  /**
+   * returns whether given item's index is activated or not
+   * @param {Number} index
+   * @returns {Boolean}
+   */
+  _isItemActivated(index) {
+    return index === this._activatedIndex;
   }
 
   _onItemClick(item) {
@@ -783,7 +796,7 @@ export class DwSelectBaseDialog extends DwCompositeDialog {
     }
 
     this._litVirtulizerEl && this._litVirtulizerEl.scrollToIndex(this._activatedIndex, "center");
-    this._scrollToIndex(this._activatedIndex, Position.END);
+    this._scrollToIndex(this._activatedIndex, Position.CENTER);
   }
 
   /**
@@ -798,7 +811,7 @@ export class DwSelectBaseDialog extends DwCompositeDialog {
     }
     setTimeout(() => {
       this._activatedIndex = selectedIndex;
-      this._scrollToIndex(selectedIndex, Position.END);
+      this._scrollToIndex(selectedIndex, Position.CENTER);
     }, 250);
   }
 


### PR DESCRIPTION
- `renderItem` has 4 parameters
- `renderItem(item, selected, activated, query)`