### PR TITLE
fix: valueTextProvider

### DIFF
--- a/dw-select.js
+++ b/dw-select.js
@@ -570,7 +570,13 @@ export class DwSelect extends DwFormElement(LitElement) {
    * Returns String that represents current value
    */
   _getValue(value) {
-    const text = this.valueTextProvider(value);
+    var text;
+    try {
+      text = this.valueTextProvider(value);
+    } catch(e) {
+      return "";
+    }
+
     if (text) {
       return text;
     }


### PR DESCRIPTION
as earlier implementation was not invoking valueTextProvider for falsy values; many users might have not considered `null` or `undefined` as input value. And function fails on such cases. So, handle any error from valueTextProvider as fallback.