### PR TITLE
fix: reset select value on dialog close.

### DIFF
--- a/dw-select.js
+++ b/dw-select.js
@@ -1098,6 +1098,9 @@ export class DwSelect extends DwFormElement(LitElement) {
     }
 
     this._opened = false;
+
+    this._resetToCurValue();
+    this.updateComplete.then(() => this.reportValidity());
   }
 
   _onKeydown(e) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that closing the selection dialog now properly resets the displayed value to the current selection and immediately updates the validity state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->