### PR TITLE
fix: reset value on dialog close issue.

### DIFF
--- a/dw-select.js
+++ b/dw-select.js
@@ -1101,8 +1101,8 @@ export class DwSelect extends DwFormElement(LitElement) {
 
     if (!this.allowNewValue) {
       this._resetToCurValue();
+      this.updateComplete.then(() => this.reportValidity());
     }
-    this.updateComplete.then(() => this.reportValidity());
   }
 
   _onKeydown(e) {

--- a/dw-select.js
+++ b/dw-select.js
@@ -1099,7 +1099,9 @@ export class DwSelect extends DwFormElement(LitElement) {
 
     this._opened = false;
 
-    this._resetToCurValue();
+    if (!this.allowNewValue) {
+      this._resetToCurValue();
+    }
     this.updateComplete.then(() => this.reportValidity());
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved select dialog behavior so that input is only reset on close if new values are not allowed, providing a more intuitive experience when custom values are permitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->