### PR TITLE
fix: select icon button size issue.

### DIFF
--- a/dw-multi-select-trigger.js
+++ b/dw-multi-select-trigger.js
@@ -43,7 +43,7 @@ export class DwMultiSelectTrigger extends DwInput {
 
         .mdc-text-field--with-trailing-icon .mdc-text-field__icon {
           position: unset;
-          margin-right: 12px;
+          margin-right: var(--dw-multi-select-trigger-trailing-icon-margin-right, 4px);
           align-self: center;
         }
 
@@ -86,6 +86,11 @@ export class DwMultiSelectTrigger extends DwInput {
        * A template for the suffix of the input field. This can be used to display additional content, such as an icon or text, after the input field.
        */
       suffixTemplate: { type: Object },
+
+      /**
+       *  Size to pass through to the internal dw-icon-button
+      */ 
+      iconButtonSize: { type: Number },
     };
   }
 

--- a/dw-multi-select.js
+++ b/dw-multi-select.js
@@ -298,6 +298,12 @@ export class DwMultiSelect extends DwFormElement(LitElement) {
       popoverStyles: { type: Object },
 
       hasItemLeadingIcon: { type: Boolean },
+
+      /**
+       * Size (px) for the trailing icon button in the trigger.
+       * Forwarded to dw-select-trigger’s dw-icon-button (.buttonSize).
+       */
+      iconButtonSize: { type: Number },
     };
   }
 
@@ -368,6 +374,7 @@ export class DwMultiSelect extends DwFormElement(LitElement) {
             ?autoValidate=${this.autoValidate}
             .error=${this.error}
             .errorMessages="${this.errorMessages}"
+            .iconButtonSize=${this.iconButtonSize}
             .warning="${this.warning}"
             .dense=${this.dense}
             .suffixTemplate=${this._inputSuffixTemplate}

--- a/dw-multi-select.js
+++ b/dw-multi-select.js
@@ -301,7 +301,7 @@ export class DwMultiSelect extends DwFormElement(LitElement) {
 
       /**
        * Size (px) for the trailing icon button in the trigger.
-       * Forwarded to dw-select-trigger’s dw-icon-button (.buttonSize).
+       * Forwarded to dw-select-multi-trigger’s dw-icon-button (.buttonSize).
        */
       iconButtonSize: { type: Number },
     };

--- a/dw-select-trigger.js
+++ b/dw-select-trigger.js
@@ -138,6 +138,11 @@ export class DwSelectTrigger extends DwInput {
       suffixTemplate: { type: Object },
 
       symbol: { type: Boolean },
+
+      /**
+       *  Size to pass through to the internal dw-icon-button
+      */ 
+      iconButtonSize: { type: Number },
     };
   }
 

--- a/dw-select-trigger.js
+++ b/dw-select-trigger.js
@@ -55,7 +55,7 @@ export class DwSelectTrigger extends DwInput {
 
         .mdc-text-field--with-trailing-icon .mdc-text-field__icon {
           position: unset;
-          margin-right: 12px;
+          margin-right: 4px;
           align-self: center;
         }
 

--- a/dw-select-trigger.js
+++ b/dw-select-trigger.js
@@ -139,9 +139,9 @@ export class DwSelectTrigger extends DwInput {
 
       symbol: { type: Boolean },
 
-      /**
-       *  Size to pass through to the internal dw-icon-button
-      */ 
+     /**
+      * Size to pass through to the internal dw-icon-button
+      */
       iconButtonSize: { type: Number },
     };
   }

--- a/dw-select-trigger.js
+++ b/dw-select-trigger.js
@@ -55,7 +55,7 @@ export class DwSelectTrigger extends DwInput {
 
         .mdc-text-field--with-trailing-icon .mdc-text-field__icon {
           position: unset;
-          margin-right: 4px;
+          margin-right: var(--dw-select-trigger-trailing-icon-margin-right, 4px);
           align-self: center;
         }
 

--- a/dw-select.js
+++ b/dw-select.js
@@ -481,6 +481,12 @@ export class DwSelect extends DwFormElement(LitElement) {
       },
 
       interactiveDialog: { type: Boolean },
+
+      /**
+       * Size (px) for the trailing icon button in the trigger.
+       * Forwarded to dw-select-trigger’s dw-icon-button (.buttonSize).
+       */
+      iconButtonSize: { type: Number },
     };
   }
 
@@ -666,6 +672,7 @@ export class DwSelect extends DwFormElement(LitElement) {
           id="trigger-icon"
           class="read-only-trigger-icon"
           ?error=${this.error && this.errorInTooltip}
+          .buttonSize=${this.iconButtonSize}
           ?warning=${this.warning && this.warningInTooltip}
           icon=${this._opened ? 'expand_less' : 'expand_more'}
           iconFont="OUTLINED"

--- a/dw-select.js
+++ b/dw-select.js
@@ -637,6 +637,7 @@ export class DwSelect extends DwFormElement(LitElement) {
             .errorTooltipActions="${this.errorTooltipActions}"
             .warningTooltipActions="${this.warningTooltipActions}"
             .tipPlacement="${this.tipPlacement}"
+            .iconButtonSize=${this.iconButtonSize}
             .dense=${this.dense}
             .autoComplete=${this.autoComplete}
             .suffixTemplate=${this._inputSuffixTemplate}


### PR DESCRIPTION
card link: https://app.kerika.net/acc_7araR1FVpSBR4YqEpigNdw/board/brd_7URTPkJW8a9n1NEkgCYTxk/crd_6b3ED11KvBDSMyEDJLGtxg?tab=attachments&referrer-page=VIEWS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select and Multi-select controls add a public setting to configure trailing icon button size for consistent sizing across triggers.

* **Style**
  * Trailing icon spacing reduced for a more compact layout.
  * Trailing icon margin is now adjustable via a CSS variable with a smaller default (4px) for improved visual balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->