### PR TITLE
fix: select trigger label padding var.

### DIFF
--- a/dw-select-trigger.js
+++ b/dw-select-trigger.js
@@ -49,6 +49,10 @@ export class DwSelectTrigger extends DwInput {
           pointer-events: unset;
         }
 
+        .mdc-notched-outline__notch {
+          padding: var(--dw-select-trigger-label-padding, 0px 38px 0px 0px);
+        }
+
         .up-down-arrow {
           transition: 0.2s ease-in-out;
         }


### PR DESCRIPTION
card link: https://app.kerika.net/acc_7araR1FVpSBR4YqEpigNdw/board/brd_4jC4aIuKkmq39kuXeWciIe/crd_6fRyOV1G1p0QrFSvNqTiNE?tab=attachments&referrer-page=VIEWS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing select field notch/label padding via a CSS variable, enabling easier theming and layout control.

* **Style**
  * Updated default padding of the select outline notch to improve visual alignment and spacing without altering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->